### PR TITLE
Roll back enforcing core FQCN

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -3,3 +3,4 @@
 
 skip_list:
   - command-instead-of-shell
+  - fqcn[action-core] # for backwards compatibility

--- a/tasks/build_command.yml
+++ b/tasks/build_command.yml
@@ -1,39 +1,39 @@
 # assumes install_command is set
 ---
 - name: Translate target names
-  ansible.builtin.set_fact:
+  set_fact:
     target_names: "{{ target_names + [target_name_map[item]] }}"
   loop: "{{ targets }}"
   vars:
     target_names: []
 
 - name: Attach install targets
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: "{{ install_command }} -n {{ target_names | join(',') }}"
 
 - name: Attach optional verbosity
   when: verbosity is defined
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: "{{ install_command }} --{{ verbosity }}"
 
 - name: Build default CLI tags
-  ansible.builtin.set_fact:
+  set_fact:
     cli_tags:
       nr_deployed_by: ansible-install
 
 - name: Add optional CLI tags
   when: tags is defined
-  ansible.builtin.set_fact:
+  set_fact:
     cli_tags: "{{ cli_tags | combine(tags) }}"
 
 - name: Attach tags
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: "{{ install_command }} --tag {{ cli_tags.keys() | zip(cli_tags.values()) | map('join', ':') | join(',') }}"
 
 - name: Create install command report
-  ansible.builtin.set_fact:
+  set_fact:
     install_command_report: r"{{ install_command | regex_replace('(?<=NEW_RELIC_API_KEY=)[^\s]*', '<hidden>') }}"
 
 - name: Report install command
-  ansible.builtin.debug:
+  debug:
     msg: "{{ install_command_report }}"

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,48 +1,48 @@
 ---
 - name: Set base install command
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: NEW_RELIC_ACCOUNT_ID={{ account_id }} NEW_RELIC_API_KEY={{ api_key }} NEW_RELIC_REGION={{ region }} /usr/local/bin/newrelic install -y
 
 - name: Build full install command
-  ansible.builtin.import_tasks: build_command.yml
+  import_tasks: build_command.yml
 
 - name: Set log file path if verbose output
   when: verbosity is defined
-  ansible.builtin.set_fact:
+  set_fact:
     log_file_path: "{{ verbosity_on_log_file_path_linux }}/newrelic-cli-{{ verbosity }}.log"
 
 - name: Set default install task timeout
   when: install_timeout_seconds is undefined
-  ansible.builtin.set_fact:
+  set_fact:
     install_timeout_seconds: "{{ default_install_timeout_seconds }}"
 
 - name: Download install.sh
-  ansible.builtin.get_url:
+  get_url:
     url: "{{ cli_install_url }}"
     dest: "{{ cli_install_download_location }}/install.sh"
     mode: 0777
 
 - name: Run install.sh
-  ansible.builtin.command: "{{ cli_install_download_location }}/install.sh"
+  command: "{{ cli_install_download_location }}/install.sh"
   register: install_script
   changed_when: install_script.rc == 0
 
 - name: Report install script output
-  ansible.builtin.debug:
+  debug:
     var: install_script.stdout_lines
 
 - name: Save verbose output to log file
   when: verbosity is defined
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: "{{ install_command }} 2>&1 | tee {{ log_file_path }}"
 
 - name: Report verbose output log file path
   when: verbosity is defined
-  ansible.builtin.debug:
+  debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
 - name: Run CLI install
-  ansible.builtin.shell: "{{ install_command }}"
+  shell: "{{ install_command }}"
   become: true
   register: result
   changed_when: true
@@ -50,5 +50,5 @@
   poll: 10
 
 - name: Set output
-  ansible.builtin.set_fact:
+  set_fact:
     output: "{{ result.stdout_lines }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Validate variables
-  ansible.builtin.import_tasks: validate.yml
+  import_tasks: validate.yml
   run_once: true
 
 - name: Run Linux install
-  ansible.builtin.import_tasks: linux.yml
+  import_tasks: linux.yml
   when:
     - os_name != 'windows'
 
 - name: Run Windows install
-  ansible.builtin.import_tasks: windows.yml
+  import_tasks: windows.yml
   when:
     - os_name == 'windows'
 
 - name: Summarize results
-  ansible.builtin.import_tasks: summary.yml
+  import_tasks: summary.yml

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -1,34 +1,34 @@
 ---
 - name: Get installation summary coordinates
-  ansible.builtin.set_fact:
+  set_fact:
     index: "{{ lookup('ansible.utils.index_of', output, 'regex', '.*Installation Summary') }}"
     length: "{{ output | length }}"
 
 - name: Get installation summary lines
-  ansible.builtin.set_fact:
+  set_fact:
     summary_lines: "{{ output[index | int : length | int] }}"
 
 - name: Filter debug/trace lines
-  ansible.builtin.set_fact:
+  set_fact:
     summary_lines: "{{ summary_lines | reject('match', 'level=') | list }}"
 
 - name: Detect installation completed
-  ansible.builtin.set_fact:
+  set_fact:
     install_complete: "{{ (summary_lines | length > 0) and (summary_lines | select('search', 'We encountered an issue*') | list | length == 0) }}"
 
 - name: Create installation summary
-  ansible.builtin.set_fact:
+  set_fact:
     summary:
       status: "{{ 'COMPLETE' if install_complete else 'INCOMPLETE' }}"
       node: "{{ ansible_facts['nodename'] }}"
       summary: "{{ summary_lines }}"
 
 - name: Report complete installs
-  ansible.builtin.debug:
+  debug:
     msg: "{{ summary }}"
   when: install_complete
 
 - name: Report incomplete installs
-  ansible.builtin.debug:
+  debug:
     msg: "{{ summary }}"
   when: not install_complete

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,13 +1,13 @@
 ---
 - name: Validate role vars
-  ansible.builtin.assert:
+  assert:
     that:
       - verbosity is not defined or verbosity in ("debug","trace")
       - install_timeout_seconds is not defined or install_timeout_seconds is integer
     quiet: true
 
 - name: Validate targets
-  ansible.builtin.assert:
+  assert:
     that:
       - target_name_map[item] is defined
     quiet: true

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,14 +1,14 @@
 ---
 - name: Set base install command
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: '& "C:\Program Files\New Relic\New Relic CLI\newrelic.exe" install -y'
 
 - name: Build install command
-  ansible.builtin.import_tasks: build_command.yml
+  import_tasks: build_command.yml
 
 - name: Set log file path if verbose output
   when: verbosity is defined
-  ansible.builtin.set_fact:
+  set_fact:
     log_file_path: "{{ verbosity_on_log_file_path_windows }}\\newrelic-cli-{{ verbosity }}.log"
 
 - name: Touch verbose output log file
@@ -19,16 +19,16 @@
 
 - name: Report verbose output log file path
   when: verbosity is defined
-  ansible.builtin.debug:
+  debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
 - name: Redirect stderr to stdout
-  ansible.builtin.set_fact:
+  set_fact:
     install_command: "{{ install_command }} 2>&1"
 
 - name: Set default install timeout
   when: install_timeout_seconds is undefined
-  ansible.builtin.set_fact:
+  set_fact:
     install_timeout_seconds: "{{ default_install_timeout_seconds }}"
 
 - name: Run install script
@@ -46,7 +46,7 @@
   ignore_errors: true
 
 - name: Set output
-  ansible.builtin.set_fact:
+  set_fact:
     output: "{{ result.stdout_lines }}"
 
 - name: Write verbose output to log file


### PR DESCRIPTION
Rolls back changes enforced by ansible-lint to use the FQCN for core modules. This allows the role to be run using Ansible versions <2.10