### PR TITLE
Enable environment variable override in playbook

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,4 +1,7 @@
 ---
+- name: Override environment variables if defined in playbook
+  ansible.builtin.import_tasks: override_env.yml
+
 - name: Set base install command
   ansible.builtin.set_fact:
     install_command: NEW_RELIC_ACCOUNT_ID={{ account_id }} NEW_RELIC_API_KEY={{ api_key }} NEW_RELIC_REGION={{ region }} /usr/local/bin/newrelic install -y

--- a/tasks/override_env.yml
+++ b/tasks/override_env.yml
@@ -5,16 +5,16 @@
     env_overrides: "{{ environment[(environment | length) - 1] }}"
 
 - name: Override environment variable NEW_RELIC_ACCOUNT_ID
-  when: env_overrides is defined
+  when: env_overrides is defined and env_overrides.NEW_RELIC_ACCOUNT_ID is defined
   ansible.builtin.set_fact:
     account_id: "{{ env_overrides.NEW_RELIC_ACCOUNT_ID }}"
 
 - name: Override environment variable NEW_RELIC_API_KEY
-  when: env_overrides is defined
+  when: env_overrides is defined and env_overrides.NEW_RELIC_API_KEY is defined
   ansible.builtin.set_fact:
     api_key: "{{ env_overrides.NEW_RELIC_API_KEY }}"
 
 - name: Override environment variable NEW_RELIC_REGION
-  when: env_overrides is defined
+  when: env_overrides is defined and env_overrides.NEW_RELIC_REGION is defined
   ansible.builtin.set_fact:
     region: "{{ env_overrides.NEW_RELIC_REGION }}"

--- a/tasks/override_env.yml
+++ b/tasks/override_env.yml
@@ -1,0 +1,20 @@
+---
+- name: Use environment from playbook if defined
+  when: ( environment | type_debug ) == 'list' and (environment | length ) > 0
+  ansible.builtin.set_fact:
+    env_overrides: "{{ environment[(environment | length) - 1] }}"
+
+- name: Override environment variable NEW_RELIC_ACCOUNT_ID
+  when: env_overrides is defined
+  ansible.builtin.set_fact:
+    account_id: "{{ env_overrides.NEW_RELIC_ACCOUNT_ID }}"
+
+- name: Override environment variable NEW_RELIC_API_KEY
+  when: env_overrides is defined
+  ansible.builtin.set_fact:
+    api_key: "{{ env_overrides.NEW_RELIC_API_KEY }}"
+
+- name: Override environment variable NEW_RELIC_REGION
+  when: env_overrides is defined
+  ansible.builtin.set_fact:
+    region: "{{ env_overrides.NEW_RELIC_REGION }}"

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,4 +1,7 @@
 ---
+- name: Check for environment overrides
+  ansible.builtin.import_tasks: override_env.yml
+
 - name: Set base install command
   ansible.builtin.set_fact:
     install_command: '& "C:\Program Files\New Relic\New Relic CLI\newrelic.exe" install -y'

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check for environment overrides
+- name: Override environment variables if defined in playbook
   ansible.builtin.import_tasks: override_env.yml
 
 - name: Set base install command

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,4 @@
 os_name: "{{ ansible_os_family | lower }}"
 account_id: "{{ lookup('env', 'NEW_RELIC_ACCOUNT_ID', default=Undefined) }}"
 api_key: "{{ lookup('env', 'NEW_RELIC_API_KEY', default=Undefined) }}"
-region: "{{ lookup('env', 'NEW_RELIC_REGION', default=Undefined) }}"
+region: "{{ lookup('env', 'NEW_RELIC_REGION', default='US') }}"


### PR DESCRIPTION
Enables overriding the terminal environment using the `environment` field at the play or role level.

## Behavior

Uses environment variables:
```
- name: Install New Relic infrastructure & logs
  hosts: all
  roles:
    - role: newrelic.newrelic_install
```

Uses play-level `environment` "FOO":
```
- name: Install New Relic infrastructure & logs
  hosts: all
  roles:
    - role: newrelic.newrelic_install
  environment:
    NEW_RELIC_ACCOUNT_ID: FOO
    NEW_RELIC_API_KEY: FOO
    NEW_RELIC_REGION: FOO
```

Uses role-level `environment` "BAR":
```
- name: Install New Relic infrastructure & logs
  hosts: all
  roles:
    - role: newrelic.newrelic_install
      environment:
        NEW_RELIC_ACCOUNT_ID: BAR
        NEW_RELIC_API_KEY: BAR
        NEW_RELIC_REGION: BAR
  environment:
    NEW_RELIC_ACCOUNT_ID: FOO
    NEW_RELIC_API_KEY: FOO
    NEW_RELIC_REGION: FOO
```