### PR TITLE
Define required environment variables in playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ After installing, include the `newrelic.newrelic_install` role in a new or exist
   hosts: all
   roles:
     - role: newrelic.newrelic_install
-      environment:
-        NEW_RELIC_API_KEY=<API key>
-        NEW_RELIC_ACCOUNT_ID=<Account ID>
-        NEW_RELIC_REGION=<Region>
+  environment:
+    NEW_RELIC_API_KEY=<API key>
+    NEW_RELIC_ACCOUNT_ID=<Account ID>
+    NEW_RELIC_REGION=<Region>
 ```
 
 ## Variables
@@ -92,7 +92,8 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
 ## Example Playbook
 
 ```
-- hosts: all
+- name: Install New Relic infrastructure & logs
+  hosts: all
   roles:
     - role: newrelic.newrelic_install
       vars:
@@ -103,11 +104,11 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
           environment: production
         install_timeout_seconds: 1000
         verbosity: debug
-      environment:
-        NEW_RELIC_API_KEY=<API key>
-        NEW_RELIC_ACCOUNT_ID=<Account ID>
-        NEW_RELIC_REGION=<Region>
-        HTTPS_PROXY: http://my.proxy:8888
+  environment:
+    NEW_RELIC_API_KEY=<API key>
+    NEW_RELIC_ACCOUNT_ID=<Account ID>
+    NEW_RELIC_REGION=<Region>
+    HTTPS_PROXY: http://my.proxy:8888
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -33,25 +33,25 @@ After installing, include the `newrelic.newrelic_install` role in a new or exist
   hosts: all
   roles:
     - role: newrelic.newrelic_install
+      environment:
+        NEW_RELIC_API_KEY=<API key>
+        NEW_RELIC_ACCOUNT_ID=<Account ID>
+        NEW_RELIC_REGION=<Region>
 ```
-
-Ensure that the following environment variables are set in your terminal before running the playbook:
-
-- `NEW_RELIC_API_KEY`
-- `NEW_RELIC_ACCOUNT_ID`
-- `NEW_RELIC_REGION`
 
 ## Variables
 
 ### Environment variables
 
-Values are read from environment in [vars/main.yml](https://github.com/newrelic/ansible-install/blob/main/vars/main.yml)
+Values are set under the `environment` keyword in your playbook:
 
-- `NEW_RELIC_API_KEY`
-- `NEW_RELIC_ACCOUNT_ID`
-- `NEW_RELIC_REGION`
+- `NEW_RELIC_API_KEY` (required)
+- `NEW_RELIC_ACCOUNT_ID` (required)
+- `NEW_RELIC_REGION` (optional, default 'US')
 
-Additionally, an optional `HTTPS_PROXY` variable can be set to enable a proxy for your installation. Add it to the `environment` keyword in your `playbook`. See [ansible's remote environment](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_environment.html) for more info.
+Additionally, an optional `HTTPS_PROXY` variable can be set to enable a proxy for your installation.
+
+See [ansible's remote environment](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_environment.html) for more info.
 
 ### Role variables
 
@@ -103,13 +103,11 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
           environment: production
         install_timeout_seconds: 1000
         verbosity: debug
-  environment:
-    HTTPS_PROXY: http://my.proxy:8888
-
-The following environment variables need to be set on the controller:
-    NEW_RELIC_API_KEY: <API_KEY>
-    NEW_RELIC_ACCOUNT_ID: <ACCOUNT_ID>
-    NEW_RELIC_REGION: <REGION> ("US" or "EU")
+      environment:
+        NEW_RELIC_API_KEY=<API key>
+        NEW_RELIC_ACCOUNT_ID=<Account ID>
+        NEW_RELIC_REGION=<Region>
+        HTTPS_PROXY: http://my.proxy:8888
 ```
 
 ## Support

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set base install command
   ansible.builtin.set_fact:
-    install_command: NEW_RELIC_ACCOUNT_ID={{ account_id }} NEW_RELIC_API_KEY={{ api_key }} NEW_RELIC_REGION={{ region }} /usr/local/bin/newrelic install -y
+    install_command: /usr/local/bin/newrelic install -y
 
 - name: Build full install command
   ansible.builtin.import_tasks: build_command.yml

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,15 +1,24 @@
 ---
-- name: Validate environment variables on remote host
+- name: Check ansible_env for required environment variables
+  set_fact:
+    NEW_RELIC_ACCOUNT_ID_is_set: "{{ ansible_env.NEW_RELIC_ACCOUNT_ID is defined }}"
+    NEW_RELIC_API_KEY_is_set: "{{ ansible_env.NEW_RELIC_API_KEY is defined }}"
+
+- name: Check environment for required environment variables
+  when: not (NEW_RELIC_ACCOUNT_ID_is_set and NEW_RELIC_API_KEY_is_set)
+  loop: "{{ environment }}"
+  set_fact:
+    NEW_RELIC_ACCOUNT_ID_is_set: "{{ item.NEW_RELIC_ACCOUNT_ID is defined }}"
+    NEW_RELIC_API_KEY_is_set: "{{ item.NEW_RELIC_API_KEY is defined }}"
+  until: NEW_RELIC_ACCOUNT_ID_is_set and NEW_RELIC_API_KEY_is_set
+  retries: 0
+  no_log: true
+
+- name: Assert required environment variables are set
   ansible.builtin.assert:
     that:
-      - ansible_env.NEW_RELIC_ACCOUNT_ID is defined
-      - ansible_env.NEW_RELIC_API_KEY is defined
-    quiet: true
-
-- name: Note default region if none is set
-  when: ansible_env.NEW_RELIC_REGION is not defined
-  ansible.builtin.debug:
-    msg: "NEW_RELIC_REGION is not set. Defaulting to 'US'"
+      - NEW_RELIC_ACCOUNT_ID_is_set
+      - NEW_RELIC_API_KEY_is_set
 
 - name: Validate role vars
   ansible.builtin.assert:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -14,11 +14,15 @@
   retries: 0
   no_log: true
 
-- name: Assert required environment variables are set
+- name: Assert NEW_RELIC_ACCOUNT_ID is set
   ansible.builtin.assert:
-    that:
-      - account_id_is_set
-      - api_key_is_set
+    that: account_id_is_set
+    msg: NEW_RELIC_ACCOUNT_ID is required and was not found. Please set this as an environment variable in your play under `environment`
+
+- name: Assert NEW_RELIC_API_KEY is set
+  ansible.builtin.assert:
+    that: api_key_is_set
+    msg: NEW_RELIC_API_KEY is required and was not found. Please set this as an environment variable in your play under `environment`
 
 - name: Validate role vars
   ansible.builtin.assert:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,24 +1,24 @@
 ---
 - name: Check ansible_env for required environment variables
-  set_fact:
-    NEW_RELIC_ACCOUNT_ID_is_set: "{{ ansible_env.NEW_RELIC_ACCOUNT_ID is defined }}"
-    NEW_RELIC_API_KEY_is_set: "{{ ansible_env.NEW_RELIC_API_KEY is defined }}"
+  ansible.builtin.set_fact:
+    account_id_is_set: "{{ ansible_env.NEW_RELIC_ACCOUNT_ID is defined }}"
+    api_key_is_set: "{{ ansible_env.NEW_RELIC_API_KEY is defined }}"
 
 - name: Check environment for required environment variables
-  when: not (NEW_RELIC_ACCOUNT_ID_is_set and NEW_RELIC_API_KEY_is_set)
+  when: not (account_id_is_set and api_key_is_set)
   loop: "{{ environment }}"
-  set_fact:
-    NEW_RELIC_ACCOUNT_ID_is_set: "{{ item.NEW_RELIC_ACCOUNT_ID is defined }}"
-    NEW_RELIC_API_KEY_is_set: "{{ item.NEW_RELIC_API_KEY is defined }}"
-  until: NEW_RELIC_ACCOUNT_ID_is_set and NEW_RELIC_API_KEY_is_set
+  ansible.builtin.set_fact:
+    account_id_is_set: "{{ item.NEW_RELIC_ACCOUNT_ID is defined }}"
+    api_key_is_set: "{{ item.NEW_RELIC_API_KEY is defined }}"
+  until: account_id_is_set and api_key_is_set
   retries: 0
   no_log: true
 
 - name: Assert required environment variables are set
   ansible.builtin.assert:
     that:
-      - NEW_RELIC_ACCOUNT_ID_is_set
-      - NEW_RELIC_API_KEY_is_set
+      - account_id_is_set
+      - api_key_is_set
 
 - name: Validate role vars
   ansible.builtin.assert:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,4 +1,16 @@
 ---
+- name: Validate environment variables on remote host
+  ansible.builtin.assert:
+    that:
+      - ansible_env.NEW_RELIC_ACCOUNT_ID is defined
+      - ansible_env.NEW_RELIC_API_KEY is defined
+    quiet: true
+
+- name: Note default region if none is set
+  when: ansible_env.NEW_RELIC_REGION is not defined
+  debug:
+    msg: "NEW_RELIC_REGION is not set. Defaulting to 'US'"
+
 - name: Validate role vars
   ansible.builtin.assert:
     that:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -8,7 +8,7 @@
 
 - name: Note default region if none is set
   when: ansible_env.NEW_RELIC_REGION is not defined
-  debug:
+  ansible.builtin.debug:
     msg: "NEW_RELIC_REGION is not set. Defaulting to 'US'"
 
 - name: Validate role vars

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -36,9 +36,6 @@
     [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'
     (New-Object System.Net.WebClient).DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1")
     & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1
-    $env:NEW_RELIC_API_KEY='{{ api_key }}'
-    $env:NEW_RELIC_ACCOUNT_ID='{{ account_id }}'
-    $env:NEW_RELIC_REGION='{{ region }}'
     {{ install_command }}
   register: result
   async: "{{ install_timeout_seconds }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,2 @@
 ---
 os_name: "{{ ansible_os_family | lower }}"
-account_id: "{{ lookup('env', 'NEW_RELIC_ACCOUNT_ID', default=Undefined) }}"
-api_key: "{{ lookup('env', 'NEW_RELIC_API_KEY', default=Undefined) }}"
-region: "{{ lookup('env', 'NEW_RELIC_REGION', default=Undefined) }}"


### PR DESCRIPTION
Changes behavior to read required env vars `NEW_RELIC_ACCOUNT_ID` and `NEW_RELIC_API_KEY` from playbook `environment` instead of reading from terminal environment.