### PR TITLE
req: cryptography version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ If you need help with Ansible for Windows OS, take a look at [Setting up a Windo
 
 ### Ansible Galaxy
 
-`ansible-galaxy install newrelic.newrelic_install`
+```
+ansible-galaxy install newrelic.newrelic_install
+```
 
 [Link to Galaxy](https://galaxy.ansible.com/newrelic/newrelic_install)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ click==8.1.3
 click-help-colors==0.9.1
 commonmark==0.9.1
 cookiecutter==2.1.1
-cryptography==38.0.4
+cryptography==39.0.1
 docker==6.0.1
 docker-py==1.10.6
 docker-pycreds==0.4.0


### PR DESCRIPTION
Fixes dependabot alerts https://github.com/newrelic/ansible-install/security/dependabot/1 and https://github.com/newrelic/ansible-install/security/dependabot/2.