### PR TITLE
feat(apm-php): apm-php support, targets update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Values are set under the `environment` keyword in your playbook:
 - `NEW_RELIC_API_KEY` (required)
 - `NEW_RELIC_ACCOUNT_ID` (required)
 - `NEW_RELIC_REGION` (optional: 'US' or 'EU', default 'US')
+- `NEW_RELIC_APPLICATION_NAME` (optional: The PHP application name to instrument. This name will be listed under New Relic's `APM & Services`. If omitted, defaults to `PHP Application`)
 
 Additionally, an optional `HTTPS_PROXY` variable can be set to enable a proxy for your installation.
 
@@ -57,9 +58,9 @@ See [ansible's remote environment](https://docs.ansible.com/ansible/latest/playb
 
 ### Role variables
 
-#### `targets` (Optional)
+#### `targets` (Required)
 
-List of targeted installs to run on hosts. If no targets are specified, infrastructure and logs will be installed by default. Available options are listed in [defaults/main.yml](https://github.com/newrelic/ansible-install/blob/main/defaults/main.yml)
+List of targeted installs to run on hosts. Available options are: `infrastructure`, `logs` and `apm-php`. The `logs` target requires `infrastructure` which will be installed along with `logs` even if `infrastructure` is not specified in `targets`. The rest of them can be independently installed.
 
 #### `tags` (Optional)
 
@@ -83,7 +84,6 @@ Set in [defaults/main.yml](https://github.com/newrelic/ansible-install/blob/main
 - `verbosity_on_log_file_path_linux`
 - `verbosity_on_log_file_path_windows`
 - `default_install_timeout_seconds`
-- `targets`
 
 ## Versions Compatibility
 
@@ -107,6 +107,7 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
         targets:
           - infrastructure
           - logs
+          - apm-php
         tags:
           foo: bar
         install_timeout_seconds: 1000
@@ -115,6 +116,7 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
     NEW_RELIC_API_KEY: <New Relic User key>
     NEW_RELIC_ACCOUNT_ID: <Account ID>
     NEW_RELIC_REGION: <Region> ('US' or 'EU')
+    NEW_RELIC_APPLICATION_NAME: <Application Name>
     HTTPS_PROXY: http://my.proxy:8888
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,8 @@ cli_install_download_location: /tmp
 target_name_map:
   infrastructure: infrastructure-agent-installer
   logs: logs-integration
+  apm-php: php-agent-installer
 verbosity_on_log_file_path_linux: /tmp
 verbosity_on_log_file_path_windows: ""
 default_install_timeout_seconds: 600
-targets:
-  - infrastructure
-  - logs
+

--- a/tasks/build_command.yml
+++ b/tasks/build_command.yml
@@ -7,9 +7,87 @@
   vars:
     target_names: []
 
+- name: Add infrastructure if logs is in targets
+  ansible.builtin.set_fact:
+    target_names: "{{ target_names + [target_name_map['infrastructure']] }}"
+  when: "target_name_map['logs'] in target_names and target_name_map['infrastructure'] is not in target_names"
+
 - name: Attach install targets
   ansible.builtin.set_fact:
     install_command: "{{ install_command }} -n {{ target_names | join(',') }}"
+
+- name: Prepare environment variables for newrelic-cli execution
+  ansible.builtin.set_fact:
+    env_vars: ""
+
+- name: Add NEW_RELIC_CLI_SKIP_CORE environment variable
+  ansible.builtin.set_fact:
+    env_vars: "NEW_RELIC_CLI_SKIP_CORE=1"
+  when: target_name_map['logs'] is not in target_names and target_name_map['infrastructure'] is not in target_names
+
+- name: Read NEW_RELIC_API_KEY environment variable
+  ansible.builtin.shell: echo $NEW_RELIC_API_KEY
+  register: api_key
+
+- name: Set NEW_RELIC_API_KEY
+  ansible.builtin.set_fact:
+    new_relic_api_key: "{{ api_key.stdout }}"
+  no_log: true
+
+- name: Fail if NEW_RELIC_API_KEY is not set
+  ansible.builtin.fail:
+    msg: NEW_RELIC_API_KEY is not set
+  when: new_relic_api_key == ''
+
+- name: Add NEW_RELIC_API_KEY environment variable
+  ansible.builtin.set_fact:
+    env_vars: "{{ env_vars }} NEW_RELIC_API_KEY={{ new_relic_api_key }}"
+
+- name: Read NEW_RELIC_ACCOUNT_ID environment variable
+  ansible.builtin.shell: echo $NEW_RELIC_ACCOUNT_ID
+  register: account_id
+
+- name: Set NEW_RELIC_ACCOUNT_ID
+  ansible.builtin.set_fact: 
+    new_relic_account_id: "{{ account_id.stdout }}"
+
+- name: Fail if NEW_RELIC_ACCOUNT_ID is not set
+  ansible.builtin.fail:
+    msg: NEW_RELIC_ACCOUNT_ID is not set
+  when: new_relic_account_id == ''
+
+- name: Add NEW_RELIC_ACCOUNT_ID environment variable
+  ansible.builtin.set_fact:
+    env_vars: "{{ env_vars }} NEW_RELIC_ACCOUNT_ID={{ new_relic_account_id }}"
+
+- name: Read NEW_RELIC_REGION environment variable
+  ansible.builtin.shell: echo $NEW_RELIC_REGION
+  register: region
+
+- name: Set NEW_RELIC_REGION
+  ansible.builtin.set_fact:
+    new_relic_region: "{{ region.stdout }}"
+
+- name: Default NEW_RELIC_REGION if none specified
+  ansible.builtin.set_fact:
+    new_relic_region: "{{ new_relic_region | default('US', True) | upper }}"
+
+- name: Add NEW_RELIC_REGION environment variable
+  ansible.builtin.set_fact:
+    env_vars: "{{ env_vars }} NEW_RELIC_REGION={{ new_relic_region }}"
+
+- name: Get NEW_RELIC_APPLICATION_NAME environment variable
+  ansible.builtin.command: echo $NEW_RELIC_APPLICATION_NAME
+  register: new_relic_application_name
+
+- name: Add NEW_RELIC_APPLICATION_NAME environment variable
+  ansible.builtin.set_fact:
+    env_vars: "{{ env_vars }} NEW_RELIC_APPLICATION_NAME={{ new_relic_application_name.stdout }}"
+  when: new_relic_application_name.stdout != ''
+
+- name: Attach environment variables
+  ansible.builtin.set_fact:
+    install_command: "{{ env_vars }} {{ install_command }}"
 
 - name: Attach optional verbosity
   when: verbosity is defined
@@ -28,7 +106,11 @@
 
 - name: Attach tags
   ansible.builtin.set_fact:
-    install_command: "{{ install_command }} --tag {{ cli_tags.keys() | zip(cli_tags.values()) | map('join', ':') | join(',') }}"
+    install_command: "{{ install_command }} --tag {{ cli_tags.keys() | zip(cli_tags.values()) | map('join', ':') | join(',') }} "
+
+- name: Add sudo
+  ansible.builtin.set_fact:
+    install_command: "sudo {{ install_command }}"
 
 - name: Create install command report
   ansible.builtin.set_fact:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -41,6 +41,15 @@
   ansible.builtin.debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
+- name: CLI install profile
+  ansible.builtin.shell: "/usr/local/bin/newrelic profiles add --profile install --apiKey {{ new_relic_api_key }} --accountId {{ new_relic_account_id }} --region {{ new_relic_region|upper }} -y"
+  become: true
+  no_log: true
+
+- name: Default CLI profile
+  shell: "/usr/local/bin/newrelic profiles default --profile install"
+  become: true
+
 - name: Run CLI install
   ansible.builtin.shell: "{{ install_command }}"
   become: true

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,4 +1,19 @@
 ---
+- name: Targets is set
+  ansible.builtin.assert:
+    that: targets is defined
+    fail_msg: "'targets' must be set"
+
+- name: Check targets is empty
+  ansible.builtin.set_fact:
+    no_targets: "{{ true if not targets }}"
+  when: targets is defined
+
+- name: Targets contains at least one installation target
+  ansible.builtin.assert:
+    that: no_targets != true
+    fail_msg: "Targets must contain at least one installation target"
+
 - name: Check ansible_env for required environment variables
   ansible.builtin.set_fact:
     account_id_is_set: "{{ ansible_env.NEW_RELIC_ACCOUNT_ID is defined }}"


### PR DESCRIPTION
Addresses the following requirements:

- `targets` is now required; if `targets` is missing or if `targets` is specified but contains no values, errors out for user to correct.
- Installs what is specified in `targets`. Only exception for this behavior if `logs`: If `logs` is in `targets` but `infrastructure` is not, `infrastructure` is added to `targets` and installed.
- When `apm-php` only is in `targets`, core bundle (`infra`+`logs`) is skipped and `apm-php` is the only one installed.
- `NEW_RELIC_APPLICATION_NAME` is optional, defaults to `PHP Application` if omitted.
- `README.md` updates regarding these changes.