### PR TITLE
CLI environment variable validation

### DIFF
--- a/tasks/build_command.yml
+++ b/tasks/build_command.yml
@@ -16,79 +16,6 @@
   ansible.builtin.set_fact:
     install_command: "{{ install_command }} -n {{ target_names | join(',') }}"
 
-- name: Prepare environment variables for newrelic-cli execution
-  ansible.builtin.set_fact:
-    env_vars: ""
-
-- name: Add NEW_RELIC_CLI_SKIP_CORE environment variable
-  ansible.builtin.set_fact:
-    env_vars: "NEW_RELIC_CLI_SKIP_CORE=1"
-  when: target_name_map['logs'] is not in target_names and target_name_map['infrastructure'] is not in target_names
-
-- name: Read NEW_RELIC_API_KEY environment variable
-  ansible.builtin.shell: echo $NEW_RELIC_API_KEY
-  register: api_key
-
-- name: Set NEW_RELIC_API_KEY
-  ansible.builtin.set_fact:
-    new_relic_api_key: "{{ api_key.stdout }}"
-  no_log: true
-
-- name: Fail if NEW_RELIC_API_KEY is not set
-  ansible.builtin.fail:
-    msg: NEW_RELIC_API_KEY is not set
-  when: new_relic_api_key == ''
-
-- name: Add NEW_RELIC_API_KEY environment variable
-  ansible.builtin.set_fact:
-    env_vars: "{{ env_vars }} NEW_RELIC_API_KEY={{ new_relic_api_key }}"
-
-- name: Read NEW_RELIC_ACCOUNT_ID environment variable
-  ansible.builtin.shell: echo $NEW_RELIC_ACCOUNT_ID
-  register: account_id
-
-- name: Set NEW_RELIC_ACCOUNT_ID
-  ansible.builtin.set_fact:
-    new_relic_account_id: "{{ account_id.stdout }}"
-
-- name: Fail if NEW_RELIC_ACCOUNT_ID is not set
-  ansible.builtin.fail:
-    msg: NEW_RELIC_ACCOUNT_ID is not set
-  when: new_relic_account_id == ''
-
-- name: Add NEW_RELIC_ACCOUNT_ID environment variable
-  ansible.builtin.set_fact:
-    env_vars: "{{ env_vars }} NEW_RELIC_ACCOUNT_ID={{ new_relic_account_id }}"
-
-- name: Read NEW_RELIC_REGION environment variable
-  ansible.builtin.shell: echo $NEW_RELIC_REGION
-  register: region
-
-- name: Set NEW_RELIC_REGION
-  ansible.builtin.set_fact:
-    new_relic_region: "{{ region.stdout }}"
-
-- name: Default NEW_RELIC_REGION if none specified
-  ansible.builtin.set_fact:
-    new_relic_region: "{{ new_relic_region | default('US', True) | upper }}"
-
-- name: Add NEW_RELIC_REGION environment variable
-  ansible.builtin.set_fact:
-    env_vars: "{{ env_vars }} NEW_RELIC_REGION={{ new_relic_region }}"
-
-- name: Get NEW_RELIC_APPLICATION_NAME environment variable
-  ansible.builtin.command: echo $NEW_RELIC_APPLICATION_NAME
-  register: new_relic_application_name
-
-- name: Add NEW_RELIC_APPLICATION_NAME environment variable
-  ansible.builtin.set_fact:
-    env_vars: "{{ env_vars }} NEW_RELIC_APPLICATION_NAME=\"{{ new_relic_application_name.stdout }}\""
-  when: new_relic_application_name.stdout != '' and target_name_map['apm-php'] in target_names
-
-- name: Attach environment variables
-  ansible.builtin.set_fact:
-    install_command: "{{ env_vars }} {{ install_command }}"
-
 - name: Attach optional verbosity
   when: verbosity is defined
   ansible.builtin.set_fact:
@@ -107,10 +34,6 @@
 - name: Attach tags
   ansible.builtin.set_fact:
     install_command: "{{ install_command }} --tag {{ cli_tags.keys() | zip(cli_tags.values()) | map('join', ':') | join(',') }} "
-
-- name: Add sudo
-  ansible.builtin.set_fact:
-    install_command: "sudo {{ install_command }}"
 
 - name: Create install command report
   ansible.builtin.set_fact:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -41,17 +41,6 @@
   ansible.builtin.debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
-- name: CLI install profile
-  ansible.builtin.shell: "/usr/local/bin/newrelic profiles add --profile install \
-    --apiKey {{ new_relic_api_key }} --accountId {{ new_relic_account_id }} \
-    --region {{ new_relic_region|upper }} -y"
-  become: true
-  no_log: true
-
-- name: Default CLI profile
-  ansible.builtin.shell: "/usr/local/bin/newrelic profiles default --profile install"
-  become: true
-
 - name: Run CLI install
   ansible.builtin.shell: "{{ install_command }}"
   become: true
@@ -59,6 +48,8 @@
   changed_when: true
   async: "{{ install_timeout_seconds }}"
   poll: 10
+  environment:
+    NEW_RELIC_CLI_SKIP_CORE: "1"
 
 - name: Set output
   ansible.builtin.set_fact:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,4 +1,25 @@
 ---
+- name: Check play environment for required variables
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    account_id_is_set: "{{ item.NEW_RELIC_ACCOUNT_ID is defined }}"
+    api_key_is_set: "{{ item.NEW_RELIC_API_KEY is defined }}"
+  retries: 0
+  no_log: true
+
+- name: Check local environment for required variables if neither is present
+  when: not account_id_is_set and not api_key_is_set
+  ansible.builtin.set_fact:
+    account_id_is_set: "{{ True if lookup('env', 'NEW_RELIC_ACCOUNT_ID', default='') else False }}"
+    api_key_is_set: "{{ True if lookup('env', 'NEW_RELIC_API_KEY', default='') else False }}"
+
+- name: Assert that required environment variables are set
+  ansible.builtin.assert:
+    that:
+      - account_id_is_set
+      - api_key_is_set
+    fail_msg: "Environment variables NEW_RELIC_ACCOUNT_ID and NEW_RELIC_API_KEY are required. Set both values in your play's environment or in your terminal."
+
 - name: Assert at least one installation target is specified
   ansible.builtin.assert:
     that:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -10,8 +10,8 @@
 - name: Check local environment for required variables if neither is present
   when: not account_id_is_set and not api_key_is_set
   ansible.builtin.set_fact:
-    account_id_is_set: "{{ True if lookup('env', 'NEW_RELIC_ACCOUNT_ID', default='') else False }}"
-    api_key_is_set: "{{ True if lookup('env', 'NEW_RELIC_API_KEY', default='') else False }}"
+    account_id_is_set: "{{ True if lookup('ansible.builtin.env', 'NEW_RELIC_ACCOUNT_ID', default='') else False }}"
+    api_key_is_set: "{{ True if lookup('ansible.builtin.env', 'NEW_RELIC_API_KEY', default='') else False }}"
 
 - name: Assert that required environment variables are set
   ansible.builtin.assert:
@@ -35,10 +35,11 @@
     quiet: true
   loop: "{{ targets }}"
 
-- name: Check for targets 'infrastructure' and 'logs'
+- name: Check for targets requiring assertions
   ansible.builtin.set_fact:
     infra_targeted: "{{ 'infrastructure' in targets }}"
     logs_targeted: "{{ 'logs' in targets }}"
+    php_targeted: "{{ 'apm-php' in targets }}"
 
 - name: Assert that logs is not targeted without infrastructure
   when: logs_targeted
@@ -46,6 +47,25 @@
     that:
       - infra_targeted is true
     fail_msg: "The logs integration is dependent on the infrastructure integration. To install logs, please also add the infrastructure agent to your targets"
+
+- name: Check for application name in play environment
+  when: php_targeted
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    application_name_is_set: "{{ item.NEW_RELIC_APPLICATION_NAME is defined }}"
+  retries: 0
+
+- name: Check for application name in local environment
+  when: php_targeted and not application_name_is_set
+  ansible.builtin.set_fact:
+    application_name_is_set: "{{ True if lookup('ansible.builtin.env', 'NEW_RELIC_APPLICATION_NAME', default='') else False }}"
+
+- name: Assert that application name is set for APM target
+  when: php_targeted
+  ansible.builtin.assert:
+    that:
+      - application_name_is_set
+    fail_msg: "Environment variable NEW_RELIC_APPLICATION_NAME is required for APM targets. Set this value in your play's environment or in your terminal."
 
 - name: Validate other role vars
   ansible.builtin.assert:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -14,41 +14,18 @@
     that: no_targets != true
     fail_msg: "Targets must contain at least one installation target"
 
-- name: Check ansible_env for required environment variables
-  ansible.builtin.set_fact:
-    account_id_is_set: "{{ ansible_env.NEW_RELIC_ACCOUNT_ID is defined }}"
-    api_key_is_set: "{{ ansible_env.NEW_RELIC_API_KEY is defined }}"
-
-- name: Check environment for required environment variables
-  when: not (account_id_is_set and api_key_is_set)
-  loop: "{{ environment }}"
-  ansible.builtin.set_fact:
-    account_id_is_set: "{{ item.NEW_RELIC_ACCOUNT_ID is defined }}"
-    api_key_is_set: "{{ item.NEW_RELIC_API_KEY is defined }}"
-  until: account_id_is_set and api_key_is_set
-  retries: 0
-  no_log: true
-
-- name: Assert NEW_RELIC_ACCOUNT_ID is set
-  ansible.builtin.assert:
-    that: account_id_is_set
-    msg: NEW_RELIC_ACCOUNT_ID is required and was not found. Please set this as an environment variable in your play under `environment`
-
-- name: Assert NEW_RELIC_API_KEY is set
-  ansible.builtin.assert:
-    that: api_key_is_set
-    msg: NEW_RELIC_API_KEY is required and was not found. Please set this as an environment variable in your play under `environment`
-
-- name: Validate role vars
-  ansible.builtin.assert:
-    that:
-      - verbosity is not defined or verbosity in ("debug","trace")
-      - install_timeout_seconds is not defined or install_timeout_seconds is integer
-    quiet: true
-
 - name: Validate targets
   ansible.builtin.assert:
     that:
       - target_name_map[item] is defined
     quiet: true
   loop: "{{ targets }}"
+
+- name: Validate other role vars
+  ansible.builtin.assert:
+    that:
+      - verbosity is not defined or verbosity in ("debug","trace")
+      - install_timeout_seconds is not defined or install_timeout_seconds is integer
+    quiet: true
+
+

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,18 +1,11 @@
 ---
-- name: Targets is set
+- name: Assert at least one installation target is specified
   ansible.builtin.assert:
-    that: targets is defined
-    fail_msg: "'targets' must be set"
-
-- name: Check targets is empty
-  ansible.builtin.set_fact:
-    no_targets: "{{ true if not targets }}"
-  when: targets is defined
-
-- name: Targets contains at least one installation target
-  ansible.builtin.assert:
-    that: no_targets != true
-    fail_msg: "Targets must contain at least one installation target"
+    that:
+      - targets is defined
+      - targets | type_debug == 'list'
+      - targets | length > 0
+    fail_msg: "At least one installation target must be specified"
 
 - name: Validate targets
   ansible.builtin.assert:
@@ -21,11 +14,21 @@
     quiet: true
   loop: "{{ targets }}"
 
+- name: Check for targets 'infrastructure' and 'logs'
+  ansible.builtin.set_fact:
+    infra_targeted: "{{ 'infrastructure' in targets }}"
+    logs_targeted: "{{ 'logs' in targets }}"
+
+- name: Assert that logs is not targeted without infrastructure
+  when: logs_targeted
+  ansible.builtin.assert:
+    that:
+      - infra_targeted is true
+    fail_msg: "The logs integration is dependent on the infrastructure integration. To install logs, please also add the infrastructure agent to your targets"
+
 - name: Validate other role vars
   ansible.builtin.assert:
     that:
       - verbosity is not defined or verbosity in ("debug","trace")
       - install_timeout_seconds is not defined or install_timeout_seconds is integer
     quiet: true
-
-

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -41,6 +41,8 @@
   async: "{{ install_timeout_seconds }}"
   poll: 10
   ignore_errors: true
+  environment:
+    NEW_RELIC_CLI_SKIP_CORE: "1"
 
 - name: Set output
   ansible.builtin.set_fact:


### PR DESCRIPTION
Proposal to let the CLI validate the env vars it's responsible for.

Also:
- set `NEW_RELIC_CLI_SKIP_CORE=1` as unconditional default for CLI install
- remove the `newrelic profile` commands for now
- assert that logs is not targeted without infra