### PR TITLE
cleaner playbook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Ansible requirements: [requirements.yml](https://github.com/newrelic/ansible-ins
   environment:
     NEW_RELIC_API_KEY: "NRAK-123..."
     NEW_RELIC_ACCOUNT_ID: "12345678"
-    NEW_RELIC_REGION: "US" (options are "US" or "EU")
-    NEW_RELIC_APPLICATION_NAME: "PHP App"
+    NEW_RELIC_REGION: "US"
+    NEW_RELIC_APPLICATION_NAME: "My Application"
     HTTPS_PROXY: http://my.proxy:8888
 ```
 


### PR DESCRIPTION
Options for `NEW_RELIC_REGIONS` are specified under [Environment Variables](https://github.com/newrelic/ansible-install#environment-variables); the example playbook uses one of them. No need to explain those options again in the example itself.