### PR TITLE
fix(mysql): use mysql envar

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -41,7 +41,7 @@
   ansible.builtin.debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
-- name: Attached MySQL root password if obtained from remote host
+- name: Attach MySQL root password if obtained from remote host
   when: mysql_root_password_from_host is defined
   ansible.builtin.set_fact:
     install_command: "NEW_RELIC_MYSQL_ROOT_PASSWORD={{ mysql_root_password_from_host }} {{ install_command }}"

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -41,6 +41,11 @@
   ansible.builtin.debug:
     msg: Logs will be saved on host at {{ log_file_path }}
 
+- name: Attached MySQL root password if obtained from remote host
+  when: mysql_root_password_from_host is defined
+  ansible.builtin.set_fact:
+    install_command: "NEW_RELIC_MYSQL_ROOT_PASSWORD={{ mysql_root_password_from_host }} {{ install_command }}"
+
 - name: Run CLI install
   ansible.builtin.shell: "{{ install_command }}"
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   run_once: true
   when:
     - os_name != 'windows'
+    - '"mysql" in targets'
 
 - name: Run Linux install
   ansible.builtin.import_tasks: linux.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,12 @@
   ansible.builtin.import_tasks: validate.yml
   run_once: true
 
+- name: Validate MySQL required variables
+  ansible.builtin.import_tasks: validate_mysql.yml
+  run_once: true
+  when:
+    - os_name != 'windows'
+
 - name: Run Linux install
   ansible.builtin.import_tasks: linux.yml
   when:

--- a/tasks/validate_mysql.yml
+++ b/tasks/validate_mysql.yml
@@ -1,22 +1,31 @@
-- name: Check MySQL is targeted
-  ansible.builtin.set_fact:
-    mysql_targeted: "{{ 'mysql' in targets }}"
-
-- name: Check required MySQL environment variable is present
+- name: Read MySQL root password from playbook's environment
   loop: "{{ environment }}"
   ansible.builtin.set_fact:
-    mysql_root_password: "{{ item.NEW_RELIC_MYSQL_ROOT_PASSWORD }}"
+    mysql_root_password: item.NEW_RELIC_MYSQL_ROOT_PASSWORD
   when:
-    - mysql_targeted
     - item.NEW_RELIC_MYSQL_ROOT_PASSWORD is defined
+  no_log: true
 
-- name: Attempt to read MySQL root password from remote host environment
-  when: mysql_root_password is undefined
+- name: Assert MySQL root password exists in remote host if not found in playbook's environment
+  when:
+    - mysql_root_password is undefined
+  ansible.builtin.assert:
+    that:
+      - ansible_env.NEW_RELIC_MYSQL_ROOT_PASSWORD is defined
+    fail_msg: "NEW_RELIC_MYSQL_ROOT_PASSWORD environment variable is not set"
+
+- name: Read MySQL root password from remote host environment
+  when:
+    - mysql_root_password is undefined
+    - ansible_env.NEW_RELIC_MYSQL_ROOT_PASSWORD is defined
   ansible.builtin.set_fact:
     mysql_root_password_from_host: "{{ ansible_env.NEW_RELIC_MYSQL_ROOT_PASSWORD }}"
 
-- name: Assert MySQL root password
-  when: mysql_root_password is undefined
+- name: Assert MySQL root password is not empty
+  when:
+    - mysql_root_password is undefined
+    - mysql_root_password_from_host is defined
   ansible.builtin.assert:
-    that: "{{ mysql_root_password_from_host != '' }}"
-    fail_msg: "Environment variable NEW_RELIC_MYSQL_ROOT_PASSWORD must be set under `environment` or as an environment variable in the host's global non-interactive session"
+    that:
+      - mysql_root_password_from_host != ''
+    fail_msg: "NEW_RELIC_MYSQL_ROOT_PASSWORD is empty. It musts be set under `environment` in the playbook or in the remote host"

--- a/tasks/validate_mysql.yml
+++ b/tasks/validate_mysql.yml
@@ -1,0 +1,22 @@
+- name: Check MySQL is targeted
+  ansible.builtin.set_fact:
+    mysql_targeted: "{{ 'mysql' in targets }}"
+
+- name: Check required MySQL environment variable is present
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mysql_root_password: "{{ item.NEW_RELIC_MYSQL_ROOT_PASSWORD }}"
+  when:
+    - mysql_targeted
+    - item.NEW_RELIC_MYSQL_ROOT_PASSWORD is defined
+
+- name: Attempt to read MySQL root password from remote host environment
+  when: mysql_root_password is undefined
+  ansible.builtin.set_fact:
+    mysql_root_password_from_host: "{{ ansible_env.NEW_RELIC_MYSQL_ROOT_PASSWORD }}"
+
+- name: Assert MySQL root password
+  when: mysql_root_password is undefined
+  ansible.builtin.assert:
+    that: "{{ mysql_root_password_from_host != '' }}"
+    fail_msg: "Environment variable NEW_RELIC_MYSQL_ROOT_PASSWORD must be set under `environment` or as an environment variable in the host's global non-interactive session"

--- a/tasks/validate_mysql.yml
+++ b/tasks/validate_mysql.yml
@@ -29,4 +29,3 @@
     that:
       - mysql_root_password_from_host != ''
     fail_msg: "NEW_RELIC_MYSQL_ROOT_PASSWORD is empty. It musts be set under `environment` in the playbook or in the remote host"
-    

--- a/tasks/validate_mysql.yml
+++ b/tasks/validate_mysql.yml
@@ -29,3 +29,4 @@
     that:
       - mysql_root_password_from_host != ''
     fail_msg: "NEW_RELIC_MYSQL_ROOT_PASSWORD is empty. It musts be set under `environment` in the playbook or in the remote host"
+    


### PR DESCRIPTION
This PR is to make sure that the `NEW_RELIC_MYSQL_ROOT_PASSWORD` environment variable is retrieved from the host's global, non-interactive environment when that same variable is not set in the playbook's `environment` section. 

If the variable is not found in the playbook nor in the remote host's environment or is found in remote host by empty, the user informed with an error.