### PR TITLE
fix: Remove ansible.utils from deps

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -47,5 +47,4 @@ galaxy_info:
     - windows
 
 dependencies:
-  - src: ansible.utils
   - src: ansible.windows


### PR DESCRIPTION
Seeing an error downloading ansible.utils:

```
- downloading role 'utils', owned by ansible
[WARNING]: - ansible.utils was NOT installed successfully: - sorry, ansible.utils was not found on https://galaxy.ansible.com/api/.
```
Removing from dependencies for now