### PR TITLE
feat: Add functionality to install Cassandra integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ List of targeted installs to run on hosts. Available options are:
 - `mssql` (Windows)
 - `mysql` (Linux)
 - `nginx` (Linux)
+- `cassandra` (Linux)
 
 Important Notes:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ target_name_map:
   mssql: mssql-server-integration-installer
   mysql: mysql-open-source-integration
   nginx: nginx-open-source-integration
+  cassandra: cassandra-open-source-integration
 verbosity_on_log_file_path_linux: /tmp
 verbosity_on_log_file_path_windows: ""
 default_install_timeout_seconds: 600


### PR DESCRIPTION
As we required functionality to install the Cassandra integration through ansible, it seemed best to update the role here for everyone to use. 