### PR TITLE
fix incorrect handling of NEW_RELIC_MYSQL_ROOT_PASSWORD

### DIFF
--- a/tasks/validate_mysql.yml
+++ b/tasks/validate_mysql.yml
@@ -1,7 +1,7 @@
 - name: Read MySQL root password from playbook's environment
   loop: "{{ environment }}"
   ansible.builtin.set_fact:
-    mysql_root_password: item.NEW_RELIC_MYSQL_ROOT_PASSWORD
+    mysql_root_password: "{{ item.NEW_RELIC_MYSQL_ROOT_PASSWORD }}"
   when:
     - item.NEW_RELIC_MYSQL_ROOT_PASSWORD is defined
   no_log: true


### PR DESCRIPTION
**Issue:**
The playbook incorrectly outputs the literal string `"item.NEW_RELIC_MYSQL_ROOT_PASSWORD"` instead of the actual value of the environment variable.

**Fix:**
Updated the playbook to ensure proper variable interpolation. Changes include:
- Correctly wrapping `NEW_RELIC_MYSQL_ROOT_PASSWORD` in `{{ }}` in the `set_fact` task.
- Ensuring the debug task displays the actual value of `mysql_root_password`.