### PR TITLE
feat(region): add Japan (JP) region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Values are set under the [`environment`](https://docs.ansible.com/ansible/latest
 
 - `NEW_RELIC_API_KEY` (required)
 - `NEW_RELIC_ACCOUNT_ID` (required)
-- `NEW_RELIC_REGION` (optional: 'US' or 'EU', default 'US')
+- `NEW_RELIC_REGION` (optional: 'US', 'EU', or 'JP', default 'US')
 
 Additionally, an optional `HTTPS_PROXY` variable can be set to enable a proxy for your installation.
 


### PR DESCRIPTION
## Summary

Documents the Japan (JP) region as a supported value for `NEW_RELIC_REGION`. The Ansible role passes the region through to the underlying newrelic-cli, which already handles JP URL mapping, so no code changes are required here.

## Test plan

- [ ] Verify README renders with `US`, `EU`, or `JP` in the env var description.
- [ ] Smoke-test an install with `NEW_RELIC_REGION=JP` against a JP account.