### PR TITLE
fix(security): bump idna/Pygments and harden workflow permissions

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,9 @@
 name: Ansible Lint
 "on": [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/galaxy-import.yml
+++ b/.github/workflows/galaxy-import.yml
@@ -4,6 +4,9 @@ name: Galaxy Import
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ name: Release
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,10 +8,16 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 "on": [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Test Default Branch
         id: default-branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docker-py==1.10.6
 docker-pycreds==0.4.0
 enrich==1.2.7
 filelock>=3.20.3
-idna==3.7
+idna==3.15
 Jinja2>=3.1.6
 jinja2-time==0.2.0
 jsonschema==4.17.3
@@ -32,7 +32,7 @@ pathspec==0.10.3
 platformdirs==2.6.0
 pluggy==1.0.0
 pycparser==2.21
-Pygments==2.15.0
+Pygments==2.20.0
 pyrsistent==0.19.2
 python-dateutil==2.8.2
 python-slugify==7.0.0


### PR DESCRIPTION
## Summary

Resolves the 2 open Dependabot alerts and all 5 open CodeQL `actions/missing-workflow-permissions` alerts in this repo.

**Dependabot — `requirements.txt`:**
- `idna` 3.7 → 3.15 (medium — bypass of CVE-2024-3651 fix in `idna.encode()`)
- `Pygments` 2.15.0 → 2.20.0 (low — ReDoS in GUID regex)

**CodeQL — `.github/workflows/*.yml`:**
- All four workflows now declare an explicit `permissions:` block. Workflow-level default is `contents: read`; jobs get the writes they actually need:
  - `release.yml` — `github-release` job: `contents: write` (for `actions/create-release`).
  - `repolinter.yml` — `repolint` job: `contents: read` + `issues: write` (the action posts issues per `output_type: issue`).
  - `ansible-lint.yml`, `galaxy-import.yml` — read-only at workflow level (Galaxy uses an external `GALAXY_API_KEY`, not `GITHUB_TOKEN`).

## Test plan

- [ ] Verify CodeQL re-scan closes the 5 `missing-workflow-permissions` alerts after merge.
- [ ] Verify Dependabot re-scan closes alerts #49 and #50.
- [ ] Next tag-driven release still creates a GitHub Release (proves `contents: write` was applied to the right job).