### PR TITLE
feat(mssql-otel): add support for mssql-otel target

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ List of targeted installs to run on hosts. Available options are:
 - `apm-java` (Linux)
 - `apache` (Linux)
 - `mssql` (Windows)
+- `mssql-otel` (Windows, Ubuntu, RHEL)
 - `mysql` (Linux)
 - `nginx` (Linux)
 
@@ -77,6 +78,7 @@ Important Notes:
 - the `apm-nodejs` agent installation is supported only for apps managed by [PM2](https://pm2.keymetrics.io/). To install the agent using a package manager such as `npm` or `yarn` or via other installation paths, please reference our [docs](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent/).
 - the `apm-dotnet` agent installation for Windows is supported only for apps hosted by [IIS](https://www.iis.net/). Linux installations are only supported for .NET applications which run as a `systemd` service.
 - the `apm-java` agent installation supports Java running in Tomcat, Wildfly/Jboss, and Jetty (standalone). Note that this is a limited Java APM installation which instruments certain Java app servers via dynamic attachment using New Relic's Java introspector. More details [here](https://github.com/newrelic/open-install-library/blob/main/docs/guided-java.md)
+- `mssql-otel` is a separate integration from `mssql`: it monitors SQL Server via the NRDOT (New Relic distribution of the OpenTelemetry) Collector instead of the classic on-host integration, does not require the infrastructure agent, and uses its own `NR_CLI_MSSQL_*` environment variables (see below) rather than `mssql`'s `NEW_RELIC_MSSQL_*` variables.
 - the following integrations require the infrastructure agent to be installed:
   - apm-java
   - apache
@@ -135,6 +137,18 @@ Additionally, an optional `HTTPS_PROXY` variable can be set to enable a proxy fo
 - `NEW_RELIC_MSSQL_SQL_PASSWORD` (optional) Optional credential override passed to `sqlcmd` when creating the SQL user specified by `NEW_RELIC_MSSQL_DB_USERNAME`. If omitted, the default login password will be used.
 - `NEW_RELIC_MSSQL_ENABLE_BUFFER_METRICS` (optional) Enable collection of buffer pool metrics. Defaults to true
 - `NEW_RELIC_MSSQL_ENABLE_RESERVE_METRICS` (optional) Enable collection of database partition reserve space. Defaults to true
+
+#### `mssql-otel`:
+
+- `NR_CLI_MSSQL_CONFIG_PRESET` (optional) `1` for Standard or `2` for Full-feature metric collection. Defaults to `1`
+- `NR_CLI_MSSQL_SERVER` (optional) SQL Server host. Defaults to `localhost`
+- `NR_CLI_MSSQL_PORT` (optional) SQL Server port. Defaults to `1433`
+- `NR_CLI_MSSQL_SA_PASSWORD` (required unless using Windows Auth or gMSA) The SQL Server `sa` password, used once to create the monitoring login
+- `NR_CLI_MSSQL_LOGIN_NAME` (optional) Monitoring username to create. Defaults to `newrelic`
+- `NR_CLI_MSSQL_LOGIN_PASSWORD` (optional, Linux only) Password for the monitoring login. If omitted, a random password is generated
+- `NR_CLI_MSSQL_AUTH_MODE` (optional, Windows only) `1` for SQL Server Auth, `2` for Windows Auth, or `3` for gMSA. Defaults to `1`
+- `NR_CLI_MSSQL_WIN_ACCOUNT` / `NR_CLI_MSSQL_WIN_PASSWORD` (required if `NR_CLI_MSSQL_AUTH_MODE` is `2`, Windows only) Windows account (`DOMAIN\username`) and password to grant permissions to and run the collector service as
+- `NR_CLI_MSSQL_GMSA_ACCOUNT` (required if `NR_CLI_MSSQL_AUTH_MODE` is `3`, Windows only) gMSA account (`DOMAIN\gMSAName$`) to grant permissions to
 
 #### `mysql`:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ target_name_map:
   apm-java: java-agent-installer
   apache: apache-open-source-integration
   mssql: mssql-server-integration-installer
+  mssql-otel: nrdot-collector-mssql
   mysql: mysql-open-source-integration
   nginx: nginx-open-source-integration
   agent-control: agent-control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,12 @@
     - os_name != 'windows'
     - '"mysql" in targets'
 
+- name: Validate mssql-otel required variables
+  ansible.builtin.import_tasks: validate_mssql_otel.yml
+  run_once: true
+  when:
+    - '"mssql-otel" in targets'
+
 - name: Run Linux install
   ansible.builtin.import_tasks: linux.yml
   when:

--- a/tasks/validate_mssql_otel.yml
+++ b/tasks/validate_mssql_otel.yml
@@ -1,0 +1,67 @@
+- name: Read NR_CLI_MSSQL_SA_PASSWORD from play environment
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mssql_otel_sa_password: "{{ item.NR_CLI_MSSQL_SA_PASSWORD }}"
+  when:
+    - item.NR_CLI_MSSQL_SA_PASSWORD is defined
+  no_log: true
+
+- name: Read NR_CLI_MSSQL_AUTH_MODE from play environment
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mssql_otel_auth_mode: "{{ item.NR_CLI_MSSQL_AUTH_MODE }}"
+  when:
+    - item.NR_CLI_MSSQL_AUTH_MODE is defined
+
+- name: Read NR_CLI_MSSQL_WIN_ACCOUNT from play environment
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mssql_otel_win_account: "{{ item.NR_CLI_MSSQL_WIN_ACCOUNT }}"
+  when:
+    - item.NR_CLI_MSSQL_WIN_ACCOUNT is defined
+
+- name: Read NR_CLI_MSSQL_WIN_PASSWORD from play environment
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mssql_otel_win_password: "{{ item.NR_CLI_MSSQL_WIN_PASSWORD }}"
+  when:
+    - item.NR_CLI_MSSQL_WIN_PASSWORD is defined
+  no_log: true
+
+- name: Read NR_CLI_MSSQL_GMSA_ACCOUNT from play environment
+  loop: "{{ environment }}"
+  ansible.builtin.set_fact:
+    mssql_otel_gmsa_account: "{{ item.NR_CLI_MSSQL_GMSA_ACCOUNT }}"
+  when:
+    - item.NR_CLI_MSSQL_GMSA_ACCOUNT is defined
+
+- name: Assert NR_CLI_MSSQL_SA_PASSWORD is set for SQL Server authentication (default on Linux, mode 1 on Windows)
+  when:
+    - os_name != 'windows' or (mssql_otel_auth_mode | default('1')) == '1'
+  ansible.builtin.assert:
+    that:
+      - mssql_otel_sa_password is defined
+      - mssql_otel_sa_password != ''
+    fail_msg: "NR_CLI_MSSQL_SA_PASSWORD is required for the mssql-otel target. Please set this in your play under `environment`"
+
+- name: Assert Windows Auth credentials are set when NR_CLI_MSSQL_AUTH_MODE is 2
+  when:
+    - os_name == 'windows'
+    - (mssql_otel_auth_mode | default('1')) == '2'
+  ansible.builtin.assert:
+    that:
+      - mssql_otel_win_account is defined
+      - mssql_otel_win_account != ''
+      - mssql_otel_win_password is defined
+      - mssql_otel_win_password != ''
+    fail_msg: "NR_CLI_MSSQL_WIN_ACCOUNT and NR_CLI_MSSQL_WIN_PASSWORD are required for the mssql-otel target when NR_CLI_MSSQL_AUTH_MODE is 2 (Windows Auth)"
+
+- name: Assert gMSA account is set when NR_CLI_MSSQL_AUTH_MODE is 3
+  when:
+    - os_name == 'windows'
+    - (mssql_otel_auth_mode | default('1')) == '3'
+  ansible.builtin.assert:
+    that:
+      - mssql_otel_gmsa_account is defined
+      - mssql_otel_gmsa_account != ''
+    fail_msg: "NR_CLI_MSSQL_GMSA_ACCOUNT is required for the mssql-otel target when NR_CLI_MSSQL_AUTH_MODE is 3 (gMSA)"


### PR DESCRIPTION
## Summary

Adds `mssql-otel` as a supported target — SQL Server monitoring via the
NRDOT (New Relic distribution of the OpenTelemetry) Collector.

- `target_name_map`: `mssql-otel` → `nrdot-collector-mssql`, matching the
  recipe `name:` field shared across all three OS-specific recipe files
  (Windows, Debian/Ubuntu, RHEL/CentOS) — the New Relic CLI selects the
  right one per-host via `installTargets`, so one map entry covers all
  three OSes.
- New `tasks/validate_mssql_otel.yml`: asserts `NR_CLI_MSSQL_SA_PASSWORD`
  is set for the default/SQL-auth path, and validates the Windows-only
  conditional pairs (`NR_CLI_MSSQL_WIN_ACCOUNT`/`WIN_PASSWORD` for auth
  mode 2, `NR_CLI_MSSQL_GMSA_ACCOUNT` for mode 3).
- README: added `mssql-otel` to the targets table (Windows, Ubuntu, RHEL),
  a note distinguishing it from classic `mssql` (standalone, no
  infrastructure-agent dependency, separate `NR_CLI_MSSQL_*` env vars),
  and a full env var reference section.

`mssql-otel` does **not** require the `infrastructure` target, unlike
`apache`/`mysql`/`nginx`/`apm-java`.

